### PR TITLE
Allow different cuda versions, update dask xgboost API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN git config --global http.sslVerify false && \
         -r \
         -o ../../.. \
         -DUSE_ARCADIA_PYTHON=no \
-        -DUSE_SYSTEM_PYTHON=3.5 \
+        -DUSE_SYSTEM_PYTHON=3.7\
         -DPYTHON_CONFIG=python3-config \
         -DCUDA_ROOT=$(dirname $(dirname $(which nvcc)))
 ENV PYTHONPATH=$PYTHONPATH:/opt/catboost/catboost/python-package
@@ -131,5 +131,6 @@ RUN git config --global http.sslVerify false && \
         -DUSE_NCCL=ON && \
     make -j4 && \
     cd ../python-package && \
+    pip uninstall -y xgboost && \
     python setup.py install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM nvidia/cuda:9.2-devel-ubuntu16.04
+ARG CUDA_VERSION
+FROM nvidia/cuda:$CUDA_VERSION-devel-ubuntu16.04
 
 # Install conda (and use python 3.5)
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ARG CUDA_VERSION
 FROM nvidia/cuda:$CUDA_VERSION-devel-ubuntu16.04
 
-# Install conda (and use python 3.5)
+# Install conda (and use python 3.7)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
@@ -19,11 +19,10 @@ RUN apt-get update && \
         zlib1g-dev && \
     rm -rf /var/lib/apt/*
 RUN curl -o /opt/miniconda.sh \
-        -O https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh && \
+        -O https://repo.continuum.io/miniconda/Miniconda3-4.4.10-Linux-x86_64.sh  && \
     chmod +x /opt/miniconda.sh && \
     /opt/miniconda.sh -b -p /opt/conda && \
     /opt/conda/bin/conda update -n base conda && \
-    /opt/conda/bin/conda install python=3.6 && \
     rm /opt/miniconda.sh
 ENV PATH /opt/conda/bin:$PATH
 RUN conda install \
@@ -47,7 +46,8 @@ RUN conda install \
         distributed \
         tqdm && \
         conda clean -ya && \
-        pip install kaggle gputil
+        pip install kaggle dask-xgboost && \
+        conda install -c rapidsai-nightly dask-cuda
 
 # cmake
 ENV CMAKE_SHORT_VERSION 3.12

--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ datasets used here are the same as in the above repo.
 
   $ git clone https://github.com/NVIDIA/gbm-bench.git
   $ cd gbm-bench
-  $ docker build -t gbm-bench:9.2 .
+```
+Create a docker image for cuda 10.1
+```bash
+  $ docker build -t gbm-bench:10.1 . --build-args CUDA_VERSION=10.1
+```
+You can create docker images with different cuda versions as below. You will not be able to create an image for a cuda version greater than what is installed on your system.
+```bash
+  $ docker build -t gbm-bench:9.2 . --build-args CUDA_VERSION=9.2
 ```
 
 # Datasets
@@ -46,9 +53,9 @@ docker run --runtime=nvidia -it --rm \
     -v {YOUR-LOCATION/gbm-datasets}:/opt/gbm-datasets \
     -v {YOUR-LOCATION/gbm-bench}:/opt/gbm-bench \
     -v {KAGGLE-API-LOCATION/.kaggle}:/root/.kaggle \
-     gbm-bench:9.2 /bin/bash
+     gbm-bench:10.1 /bin/bash
 ```
-The above command launches an interactive session and mounts the dataset folder, the gbm-bench repo and your kaggle API key inside the container.
+The above command launches an interactive session and mounts the dataset folder, the gbm-bench repo and your kaggle API key inside the container. "gbm-bench:10.1" refers to the docker image, modify this if you are using a different cuda version.
 
 ## Running benchmarks
 Benchmarks are launched from the python runme.py script

--- a/README.md
+++ b/README.md
@@ -14,11 +14,11 @@ datasets used here are the same as in the above repo.
   $ git clone https://github.com/NVIDIA/gbm-bench.git
   $ cd gbm-bench
 ```
-Create a docker image for cuda 10.1
+Create a docker image for cuda 10.0
 ```bash
-  $ docker build -t gbm-bench:10.1 . --build-args CUDA_VERSION=10.1
+  $ docker build -t gbm-bench:10.0 . --build-args CUDA_VERSION=10.0
 ```
-You can create docker images with different cuda versions as below. You will not be able to create an image for a cuda version greater than what is installed on your system.
+You can create docker images with different cuda versions as below. You will not be able to create an image for a cuda version greater than what is installed on your system. The GBM libraries may not support very recent versions of cuda.
 ```bash
   $ docker build -t gbm-bench:9.2 . --build-args CUDA_VERSION=9.2
 ```
@@ -53,9 +53,9 @@ docker run --runtime=nvidia -it --rm \
     -v {YOUR-LOCATION/gbm-datasets}:/opt/gbm-datasets \
     -v {YOUR-LOCATION/gbm-bench}:/opt/gbm-bench \
     -v {KAGGLE-API-LOCATION/.kaggle}:/root/.kaggle \
-     gbm-bench:10.1 /bin/bash
+     gbm-bench:10.0 /bin/bash
 ```
-The above command launches an interactive session and mounts the dataset folder, the gbm-bench repo and your kaggle API key inside the container. "gbm-bench:10.1" refers to the docker image, modify this if you are using a different cuda version.
+The above command launches an interactive session and mounts the dataset folder, the gbm-bench repo and your kaggle API key inside the container. "gbm-bench:10.0" refers to the docker image, modify this if you are using a different cuda version.
 
 ## Running benchmarks
 Benchmarks are launched from the python runme.py script


### PR DESCRIPTION
This PR allows using both the new xgboost dask support as well as the old dask-xgboost package for comparison.