### PR TITLE
Sklearn covtype fixes

### DIFF
--- a/algorithms.py
+++ b/algorithms.py
@@ -150,7 +150,7 @@ class Algorithm(ABC):
 
 # learning parameters shared by all algorithms, using the xgboost convention
 shared_params = {"max_depth": 8, "learning_rate": 0.1,
-                 "reg_lambda": 1}
+                 "reg_lambda": 1, "max_samples" : 0.5}
 
 class CumlRfAlgorithm(Algorithm):
     def configure(self, data, args):
@@ -222,6 +222,7 @@ class SkRandomForestAlgorithm(Algorithm):
         del params["learning_rate"]
         params["n_estimators"] = args.ntrees
         params.update(args.extra)
+        params.update({"n_jobs" : -1})
         return params
 
     def fit(self, data, args):

--- a/datasets.py
+++ b/datasets.py
@@ -295,7 +295,11 @@ def prepare_covtype(dataset_folder, nrows):  # pylint: disable=unused-argument
     if nrows is not None:
         X = X[0:nrows]
         y = y[0:nrows]
+    # Labele range in covtype start from 1, making it start from 0
+    y = y - 1
 
+    X = np.float32(X)
+    y = np.int32(y)
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77,
                                                         test_size=0.2,
                                                         )


### PR DESCRIPTION
1. Launching sklearn RF fit with multi-thread support
2. Updating covtype dataset preprocessing to work with cuML